### PR TITLE
fix: correct API endpoint mismatch for visual characteristics

### DIFF
--- a/frontend/src/lib/api-services.ts
+++ b/frontend/src/lib/api-services.ts
@@ -391,7 +391,7 @@ export const characteristicsService = {
   },
 
   getForOrder: async (orderId: number): Promise<JobCharacteristic[]> => {
-    return api.get<JobCharacteristic[]>(`/characteristics/orders/${orderId}/characteristics`);
+    return api.get<JobCharacteristic[]>(`/orders/${orderId}/characteristics`);
   },
 
   createForOrder: async (orderId: number, characteristicData: {
@@ -400,7 +400,7 @@ export const characteristicsService = {
     color?: string;
     display_name?: string;
   }): Promise<JobCharacteristic> => {
-    return api.post<JobCharacteristic>(`/characteristics/orders/${orderId}/characteristics`, characteristicData);
+    return api.post<JobCharacteristic>(`/orders/${orderId}/characteristics`, characteristicData);
   },
 
   update: async (id: number, updates: Partial<JobCharacteristic>): Promise<JobCharacteristic> => {
@@ -412,11 +412,11 @@ export const characteristicsService = {
   },
 
   refreshForOrder: async (orderId: number): Promise<JobCharacteristic[]> => {
-    return api.post<JobCharacteristic[]>(`/characteristics/orders/${orderId}/characteristics/refresh`);
+    return api.post<JobCharacteristic[]>(`/orders/${orderId}/characteristics/refresh`);
   },
 
   detectForOrder: async (orderId: number): Promise<JobCharacteristic[]> => {
-    return api.post<JobCharacteristic[]>(`/characteristics/orders/${orderId}/characteristics/detect`);
+    return api.post<JobCharacteristic[]>(`/orders/${orderId}/characteristics/detect`);
   },
 };
 


### PR DESCRIPTION
## 🐛 Fix Description

Resolves #2 - API endpoint mismatch prevents adding visual characteristics to manufacturing orders

## 🔧 Changes Made

Updated frontend API service endpoints in `characteristicsService` to match backend route structure:

- **getForOrder**: `/characteristics/orders/${orderId}/characteristics` → `/orders/${orderId}/characteristics`
- **createForOrder**: `/characteristics/orders/${orderId}/characteristics` → `/orders/${orderId}/characteristics` 
- **refreshForOrder**: `/characteristics/orders/${orderId}/characteristics/refresh` → `/orders/${orderId}/characteristics/refresh`
- **detectForOrder**: `/characteristics/orders/${orderId}/characteristics/detect` → `/orders/${orderId}/characteristics/detect`

## ✅ Testing

- ✅ All 4 endpoints tested and verified working via API calls
- ✅ Can successfully create new visual characteristics 
- ✅ Can retrieve characteristics for orders
- ✅ Refresh and detect endpoints functional
- ✅ No new linting errors introduced

## 🎯 Impact

- **Before**: 404 errors when trying to add visual characteristics
- **After**: Full visual characteristics functionality restored
- **Users affected**: All users using the planning board visual grouping feature

## 📝 Files Changed

- `frontend/src/lib/api-services.ts` - Fixed 4 API endpoint patterns

## 🔗 Related

- Fixes #2
- Resolves critical user-facing bug in manufacturing planning board

🤖 Generated with [Claude Code](https://claude.ai/code)