### PR TITLE
feat: Change Visual Grouping Legend default state to collapsed

### DIFF
--- a/frontend/src/components/planning-board.tsx
+++ b/frontend/src/components/planning-board.tsx
@@ -356,7 +356,7 @@ function MainPlanningBoard({
   })
   const [allCharacteristics, setAllCharacteristics] = useState<JobCharacteristic[]>([])
   const [showLegend, setShowLegend] = useState(true)
-  const [legendCollapsed, setLegendCollapsed] = useState(false)
+  const [legendCollapsed, setLegendCollapsed] = useState(true)
   
   // Card collapse state - maps order ID to collapse state
   const [collapsedCards, setCollapsedCards] = useState<Record<number, boolean>>({})


### PR DESCRIPTION
Fixes #4

## Summary

Changed the default state of the Visual Grouping Legend on the manufacturing planning board from expanded to collapsed to reduce visual clutter and improve user experience.

## Changes Made

- **Frontend Enhancement**: Modified `planning-board.tsx` to change `legendCollapsed` default state from `false` to `true`
- **User Experience**: Cleaner initial view with legend details available on-demand
- **Functionality Preserved**: All existing expand/collapse toggle functionality remains unchanged

## User Impact

- **Before**: Legend was expanded by default, taking up header space immediately
- **After**: Legend is collapsed by default, showing only when users need it
- **Benefit**: Reduces cognitive load while maintaining full functionality

## Technical Details

**Single Line Change**: `useState(false)` → `useState(true)` in `legendCollapsed` state declaration

**Component Integration**:
- CharacteristicLegend properly handles collapsed state
- ChevronDown icon shows when collapsed, ChevronUp when expanded  
- Toggle functionality works seamlessly with state change
- CardContent only renders when `\!isCollapsed`

## Acceptance Criteria Met

✅ Visual Grouping Legend is collapsed by default when planning board loads  
✅ Expand/collapse toggle functionality continues to work as expected  
✅ ChevronDown icon shows when collapsed, ChevronUp when expanded  
✅ All existing legend content displays correctly when expanded  
✅ No regression in existing functionality  
✅ Improves user experience with cleaner initial view  

Closes #4